### PR TITLE
Add created file list output to patterns.bash

### DIFF
--- a/patterns.bash
+++ b/patterns.bash
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash -e
 
 EXEC="docker run --rm -e SMARTHR_TENANT=$SMARTHR_TENANT -e SMARTHR_TOKEN=$SMARTHR_TOKEN ghcr.io/yasuyuky/smarthr-imedic"
+OUTPUTS=()
 
 for f in tsv csv; do
     mkdir -p output/$f
-    $EXEC $f last last >output/$f/${SMARTHR_TENANT}$(date +"%Y%m%d").last-last.txt
-    $EXEC $f full full >output/$f/${SMARTHR_TENANT}$(date +"%Y%m%d").full-full.txt
-    $EXEC $f last full >output/$f/${SMARTHR_TENANT}$(date +"%Y%m%d").last-full.txt
-    $EXEC $f last email >output/$f/${SMARTHR_TENANT}$(date +"%Y%m%d").last-email.txt
+    for pattern in "last last" "full full" "last full" "last email"; do
+        set -- $pattern
+        output=output/$f/${SMARTHR_TENANT}$(date +"%Y%m%d").$1-$2.txt
+        $EXEC $f "$1" "$2" >"$output"
+        OUTPUTS+=("$output")
+    done
 done
+
+printf 'Created files:\n'
+printf '  %s\n' "${OUTPUTS[@]}"


### PR DESCRIPTION
## Summary
- collect generated output paths while `patterns.bash` runs
- print the created files at the end so the output location is explicit
- reduce repeated command lines by looping over pattern pairs

## Testing
- Not run (not requested)